### PR TITLE
Update to opcua.md to correct erroneous OPC-UA node name

### DIFF
--- a/doc_source/opcua.md
+++ b/doc_source/opcua.md
@@ -107,14 +107,14 @@ skipping installation of cpu_usage and memory_usage nodes
        },  
        subscriptions: [
            {   
-           name: 'MyPumpSeed',
-           nodeId: 'ns=1;s=PumpSeed',
+           name: 'MyPumpSpeed',
+           nodeId: 'ns=1;s=PumpSpeed',
            },  
        ],  
    };
    ```
 
-   In this case, we are connecting to an OPC\-UA server running on the same host as our Greengrass Core, on port 26543, and monitoring one node that has an OPC\-UA Id `'ns=1;s=PumpSeed'`\. 
+   In this case, we are connecting to an OPC\-UA server running on the same host as our Greengrass Core, on port 26543, and monitoring one node that has an OPC\-UA Id `'ns=1;s=PumpSpeed'`\. 
 
 1. Configure the authentication mode
 
@@ -186,7 +186,7 @@ You can see messages received by your Lambda function in one of two ways:
   ```
   [2017-11-14T16:33:09.05Z][INFO]-started subscription : 305964
   
-  [2017-11-14T16:33:09.05Z][INFO]-monitoring node id =  ns=1;s=PumpSeed
+  [2017-11-14T16:33:09.05Z][INFO]-monitoring node id =  ns=1;s=PumpSpeed
   
   [2017-11-14T16:33:09.099Z][INFO]-monitoredItem initialized
   


### PR DESCRIPTION
Modified "PumpSeed" into "PumpSpeed" because it is the default name of the node in node-opcua "simple_server.js", which used as the OPC-UA server.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
