### PR TITLE
Fix the checker unzip folder

### DIFF
--- a/doc_source/module1.md
+++ b/doc_source/module1.md
@@ -136,9 +136,10 @@ If you don't see the `98-rpi.conf` file, follow the instructions in the `README.
 
    ```
    cd /home/pi/Downloads
+   mkdir greengrass-dependency-checker
+   cd greengrass-dependency-checker
    wget https://github.com/aws-samples/aws-greengrass-samples/raw/master/greengrass-dependency-checker-GGCv1.8.x.zip
    unzip greengrass-dependency-checker-GGCv1.8.x.zip
-   cd greengrass-dependency-checker-GGCv1.8.x
    sudo modprobe configs
    sudo ./check_ggc_dependencies | more
    ```


### PR DESCRIPTION
Description of changes:
The archive was unzipped not into greengrass-dependency-checker-xxx folder but to the current folder. Thus we need first to create a separate folder within ~/Downloads, and do all the routines there.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
