### PR TITLE
Update docs to use correct aws cli ECR command, removing deprecated command.

### DIFF
--- a/doc_source/run-gg-in-docker-container.md
+++ b/doc_source/run-gg-in-docker-container.md
@@ -57,9 +57,7 @@ Run the following commands in your computer terminal\.
 1. <a name="docker-get-login"></a>Login to the Greengrass registry in Amazon ECR\.
 
    ```
-   aws ecr get-login-password --region us-west-2
-   aws ecr get-login-password \
-    --region  us-west-2 \
+   aws ecr get-login-password --region  us-west-2 \
     | docker login \
     --username AWS \
     --password-stdin https://216483018798.dkr.ecr.us-west-2.amazonaws.com

--- a/doc_source/run-gg-in-docker-container.md
+++ b/doc_source/run-gg-in-docker-container.md
@@ -54,18 +54,15 @@ AWS IoT Greengrass provides a Docker image that has the AWS IoT Greengrass Core 
 
 Run the following commands in your computer terminal\.
 
-1. <a name="docker-get-login"></a>Get the required login command, which contains an authorization token for the AWS IoT Greengrass registry in Amazon ECR\.
+1. <a name="docker-get-login"></a>Login to the Greengrass registry in Amazon ECR\.
 
    ```
    aws ecr get-login-password --region us-west-2
-   ```
-
-   The output is the `docker login` command that you use in the next step\.
-
-1. <a name="docker-docker-login"></a>Authenticate your Docker client to the AWS IoT Greengrass container image in the registry by running the `docker login` command from the `get-login` output\. The command should be similar to the following example\.
-
-   ```
-   docker login -u AWS -p abCzYZ123... https://216483018798.dkr.ecr.us-west-2.amazonaws.com
+   aws ecr get-login-password \
+    --region  us-west-2 \
+    | docker login \
+    --username AWS \
+    --password-stdin https://216483018798.dkr.ecr.us-west-2.amazonaws.com
    ```
 
 1. <a name="docker-docker-pull"></a>Retrieve the AWS IoT Greengrass container image\.

--- a/doc_source/run-gg-in-docker-container.md
+++ b/doc_source/run-gg-in-docker-container.md
@@ -57,7 +57,7 @@ Run the following commands in your computer terminal\.
 1. <a name="docker-get-login"></a>Get the required login command, which contains an authorization token for the AWS IoT Greengrass registry in Amazon ECR\.
 
    ```
-   aws ecr get-login --registry-ids 216483018798 --no-include-email --region us-west-2
+   aws ecr get-login-password --region us-west-2
    ```
 
    The output is the `docker login` command that you use in the next step\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When logging into Amazon ECR to be able to retrieve the Greengrass docker image, we need to use the `get-login-password` - previously the docs say to use `get-login`, which is now deprecated (see https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login.html and https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login-password.html) 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
