### PR TITLE
Remove deprecated ecr command, replace with correct version

### DIFF
--- a/doc_source/run-gg-in-docker-container.md
+++ b/doc_source/run-gg-in-docker-container.md
@@ -57,15 +57,10 @@ Run the following commands in your computer terminal\.
 1. <a name="docker-get-login"></a>Get the required login command, which contains an authorization token for the AWS IoT Greengrass registry in Amazon ECR\.
 
    ```
-   aws ecr get-login --registry-ids 216483018798 --no-include-email --region us-west-2
-   ```
-
-   The output is the `docker login` command that you use in the next step\.
-
-1. <a name="docker-docker-login"></a>Authenticate your Docker client to the AWS IoT Greengrass container image in the registry by running the `docker login` command from the `get-login` output\. The command should be similar to the following example\.
-
-   ```
-   docker login -u AWS -p abCzYZ123... https://216483018798.dkr.ecr.us-west-2.amazonaws.com
+   aws ecr get-login-password \
+    | docker login \
+    --username AWS \
+    --password-stdin https://216483018798.dkr.ecr.us-west-2.amazonaws.com
    ```
 
 1. <a name="docker-docker-pull"></a>Retrieve the AWS IoT Greengrass container image\.

--- a/doc_source/run-gg-in-docker-container.md
+++ b/doc_source/run-gg-in-docker-container.md
@@ -54,7 +54,7 @@ AWS IoT Greengrass provides a Docker image that has the AWS IoT Greengrass Core 
 
 Run the following commands in your computer terminal\.
 
-1. <a name="docker-get-login"></a>Get the required login command, which contains an authorization token for the AWS IoT Greengrass registry in Amazon ECR\.
+1. <a name="docker-get-login"></a>Login to the Amazon ECR registry which contains the Greengrass image\.
 
    ```
    aws ecr get-login-password \
@@ -108,18 +108,13 @@ You can use the editor of your choice instead of nano\.
 
 Run the following commands in your computer terminal\.
 
-1. <a name="docker-get-login"></a>Get the required login command, which contains an authorization token for the AWS IoT Greengrass registry in Amazon ECR\.
+1. <a name="docker-get-login"></a>Login to the Amazon ECR registry which contains the Greengrass image\.
 
    ```
-   aws ecr get-login --registry-ids 216483018798 --no-include-email --region us-west-2
-   ```
-
-   The output is the `docker login` command that you use in the next step\.
-
-1. <a name="docker-docker-login"></a>Authenticate your Docker client to the AWS IoT Greengrass container image in the registry by running the `docker login` command from the `get-login` output\. The command should be similar to the following example\.
-
-   ```
-   docker login -u AWS -p abCzYZ123... https://216483018798.dkr.ecr.us-west-2.amazonaws.com
+   aws ecr get-login-password \
+    | docker login \
+    --username AWS \
+    --password-stdin https://216483018798.dkr.ecr.us-west-2.amazonaws.com
    ```
 
 1. <a name="docker-docker-pull"></a>Retrieve the AWS IoT Greengrass container image\.
@@ -138,18 +133,13 @@ The `latest` tag corresponds to the latest AWS IoT Greengrass container\. You ca
 
 Run the following commands in a command prompt\. Before you can use Docker commands on Windows, Docker Desktop must be running\.
 
-1. <a name="docker-get-login"></a>Get the required login command, which contains an authorization token for the AWS IoT Greengrass registry in Amazon ECR\.
+1. <a name="docker-get-login"></a>Login to the Amazon ECR registry which contains the Greengrass image\.
 
    ```
-   aws ecr get-login --registry-ids 216483018798 --no-include-email --region us-west-2
-   ```
-
-   The output is the `docker login` command that you use in the next step\.
-
-1. <a name="docker-docker-login"></a>Authenticate your Docker client to the AWS IoT Greengrass container image in the registry by running the `docker login` command from the `get-login` output\. The command should be similar to the following example\.
-
-   ```
-   docker login -u AWS -p abCzYZ123... https://216483018798.dkr.ecr.us-west-2.amazonaws.com
+   aws ecr get-login-password \
+    | docker login \
+    --username AWS \
+    --password-stdin https://216483018798.dkr.ecr.us-west-2.amazonaws.com
    ```
 
 1. <a name="docker-docker-pull"></a>Retrieve the AWS IoT Greengrass container image\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Re-raising the PR, as my previous PR (https://github.com/awsdocs/aws-greengrass-developer-guide/pull/15) seemed to have been overwritten by another merge which occured at the same time.

Whilst doing this PR, I noticed the same deprecated command was being used elsewhere in the document as well, so I have edited all applicable parts of the document.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
